### PR TITLE
Reduce limit to something more reasonable

### DIFF
--- a/src/mflyCommands.js
+++ b/src/mflyCommands.js
@@ -777,7 +777,7 @@ var mflyCommands = function () {
             var dfd1 = $.Deferred();
             var result = [];
             obj.offset = 0;
-            obj.limit = 500;
+            obj.limit = 100;
 
             var getPage = function () {
                 var dfd2 = $.Deferred();


### PR DESCRIPTION
Paging size of 500 results is proving to be too large at the moment. Can we change it to 100?