### PR TITLE
These methods will not be supported on the web or the desktop app.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,8 +1,10 @@
 {
     "predef": [
         "$",
+        "console",
         "navigator",
         "setTimeout",
-        "window"
+        "window",
+        "sessionStorage"
     ]
 }

--- a/src/mflyCommands.js
+++ b/src/mflyCommands.js
@@ -40,7 +40,7 @@ var mflyCommands = function () {
         var unsupportedStatements = [
             'control/browse', 
             'control/email', 
-            'contro/goto', 
+            'control/goto', 
             'control/hideControlBars',
             'control/refresh',
             'control/showAddToCollection',

--- a/src/mflyCommands.js
+++ b/src/mflyCommands.js
@@ -4,8 +4,8 @@
  * Before use, please be sure to call setPrefix if you are working on a development platform (e.g.
  * a local webserver on a PC) to override mfly:// with, for example, http://localhost:8000/ .
  */
-"use strict";
 var mflyCommands = function () {
+    "use strict";
 
     /**
      * Private variables and functions
@@ -32,7 +32,38 @@ var mflyCommands = function () {
         return url + separator + 'version=5';
     }
 
+    function isControlStatementUnsupported(url) {
+        if (!_isWeb()) {
+            return false;
+        }
+
+        var unsupportedStatements = [
+            'control/browse', 
+            'control/email', 
+            'contro/goto', 
+            'control/hideControlBars',
+            'control/refresh',
+            'control/showAddToCollection',
+            'control/showAnnotations',
+            'control/showCollections',
+            'control/showControlBars',
+            'control/showNotificationsManager',
+            'control/showSearch',
+            'control/secondScreenOptions',
+            'control/showSettings',
+            'control/takeAndEmailScreenshot'
+        ];
+
+        return unsupportedStatements.some(function(statement) {
+            return url.indexOf(statement) > 0;
+        });
+    }
+
     function doControlStatement(url) {
+        if (isControlStatementUnsupported(url)) {
+            throw new Error('This method is not supported on this platform.');
+        }
+
         url = _appendVersion(url);
 
         if (_isWindows8()) {
@@ -1056,5 +1087,5 @@ var Base64 = function () {
 
             return output;
         }
-    }
+    };
 }();


### PR DESCRIPTION
You can run `mfly-interactive --url https://viewer.mediafly.com/interactives/interactive/9cf282320e6340ee8b830e5376d54531product236750/index.html` which is pointing at the generic interactive located in the interactives environment. Then, once you navigate to that interactive in your `localhost` browser tab, you can run the following commands in your devtools console to test them out. For example, running `mflyCommands.showSettings()` should throw the expected error.