### PR TITLE
Update search.ts

### DIFF
--- a/commands/search.ts
+++ b/commands/search.ts
@@ -12,7 +12,7 @@ export function search(term, offset = 0, limit = 100) {
 
 	var getPage = function() {
 		var qs = $.param(obj);
-
+		qs = qs.replace(/\+/g, '%20');
 		get('items?' + qs)
 			.done(function(data: any) {
 				result = result.concat(data);


### PR DESCRIPTION
So, when working on accept advanced search query syntax I was having trouble executing the query.

Turns out $.param() turns spaces into plus signs. I originally changed the plus signs to spaces on ios, but it felt like a bad assumption, what if I have a legit plus sign I want to send down.

I think this fixes it, because if user has a legit plus sign it is percent escaped.